### PR TITLE
Added npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,8 @@
     },
     "node_modules/@capacitor/core": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-xFy1/4qLFLp5WCIzIhtwUuVNNoz36+V7/BzHmLqgVJcvotc4MMjswW/TshnPQaLLujEOaLkA4h8ZJ0uoK3ImGg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2453,8 +2455,9 @@
       }
     },
     "node_modules/nostr-signer-capacitor-plugin": {
-      "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/chebizarro/nostr-signer-capacitor-plugin.git#2adb594b17886af706e07696c00aae808316e300",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/nostr-signer-capacitor-plugin/-/nostr-signer-capacitor-plugin-0.0.3.tgz",
+      "integrity": "sha512-Aa3gmaEsmI80zm6/+Z12CEryzVlSSB+ERUhPTUGg/juQUlYGyeynifm306URUXYF4NkrdBpJua/gmcvhXcZoUA==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -3636,16 +3639,16 @@
     },
     "packages/app": {
       "name": "@welshman/app",
-      "version": "0.0.12",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "@welshman/dvm": "~0.0.10",
         "@welshman/feeds": "~0.0.20",
         "@welshman/lib": "~0.0.21",
-        "@welshman/net": "~0.0.25",
+        "@welshman/net": "~0.0.26",
         "@welshman/signer": "~0.0.8",
         "@welshman/store": "~0.0.10",
-        "@welshman/util": "~0.0.37",
+        "@welshman/util": "~0.0.38",
         "fuse.js": "^7.0.0",
         "idb": "^8.0.0",
         "svelte": "^4.2.18",
@@ -3727,7 +3730,7 @@
     },
     "packages/net": {
       "name": "@welshman/net",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
         "@welshman/lib": "~0.0.21",
@@ -3758,7 +3761,7 @@
         "typescript": "~5.1.6"
       },
       "peerDependencies": {
-        "nostr-signer-capacitor-plugin": "github:chebizarro/nostr-signer-capacitor-plugin"
+        "nostr-signer-capacitor-plugin": "^0.0.3"
       }
     },
     "packages/store": {
@@ -3778,7 +3781,7 @@
     },
     "packages/util": {
       "name": "@welshman/util",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "license": "MIT",
       "dependencies": {
         "@welshman/lib": "~0.0.21",

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -37,6 +37,6 @@
     "nostr-tools": "^2.7.2"
   },
   "peerDependencies": {
-    "nostr-signer-capacitor-plugin": "github:chebizarro/nostr-signer-capacitor-plugin"
+    "nostr-signer-capacitor-plugin": "^0.0.3"
   }
 }


### PR DESCRIPTION
I've published the signer plugin to npm and made a small but important API change to the `AppInfo` object which now returns the signer app's icon as both `AppInfo.iconData` which is the base 64 encoded icon data and `AppInfo.iconUrl` which is the full URL `data:image/png;base64,` plus the base 64 encoded icon.