### PR TITLE
Always call get_public_key on NIP46 signer, but cache result locally

### DIFF
--- a/packages/signer/src/signers/nip46.ts
+++ b/packages/signer/src/signers/nip46.ts
@@ -138,6 +138,10 @@ export class Nip46Broker extends Emitter {
     return this.#connectResult === "ack"
   }
 
+  getPublicKey = () => {
+    return this.request("get_public_key", [])
+  }
+
   signEvent = async (event: StampedEvent) => {
     return JSON.parse(await this.request("sign_event", [JSON.stringify(event)]) as string)
   }
@@ -165,9 +169,16 @@ export class Nip46Broker extends Emitter {
 }
 
 export class Nip46Signer implements ISigner {
+  userPubkeyCached: string | undefined
+
   constructor(private broker: Nip46Broker) {}
 
-  getPubkey = async () => this.broker.pubkey
+  getPubkey = async () => {
+    if (!this.userPubkeyCached) {
+      this.userPubkeyCached = await this.broker.getPublicKey()
+    }
+    return this.userPubkeyCached
+  }
 
   sign = (template: StampedEvent) =>
     this.broker.signEvent(hash(own(template, this.broker.pubkey)))


### PR DESCRIPTION
Although a very simple change I thought this was going to work, but when I tried to run Coracle with the local welshman dependencies I ran into a million problems and then when it finally ran it was hitting some [seemingly unrelated errors](https://github.com/user-attachments/assets/9ce1039a-43d2-4ff7-ab1c-7e6e5cd40c97) (which also happen when I run Coracle locally without modifying the dependencies), so I gave up and opened this PR that I know will be rejected.

Addresses https://github.com/nostr-protocol/nips/pull/1545.