### PR TITLE
Default to NIP04 for sending messages

### DIFF
--- a/packages/signer/src/signers/nip46.ts
+++ b/packages/signer/src/signers/nip46.ts
@@ -134,7 +134,7 @@ export class Nip46Sender extends Emitter {
 
   public send = async (request: Nip46Request) => {
     const {id, method, params} = request
-    const {relays, signerPubkey, algorithm = "nip44"} = this.params
+    const {relays, signerPubkey, algorithm = "nip04"} = this.params
 
     if (!signerPubkey) {
       throw new Error("Unable to send nip46 request without a signer pubkey")


### PR DESCRIPTION
As per NIP46, the content send out must be encrypted with NIP04, not NIP44. Not sure if NIP44 should even be an option, since the encryption algorithm is never negotiated in the protocol.  