### PR TITLE
Fix LRU cache eviction

### DIFF
--- a/packages/lib/__tests__/LRUCache.test.ts
+++ b/packages/lib/__tests__/LRUCache.test.ts
@@ -34,20 +34,45 @@ describe("Caches", () => {
       })
 
       it("should update access order on get", () => {
-        cache.set("a", 1) // keys = [a]
-        cache.set("b", 2) // keys = [a, b]
-        cache.set("c", 3) // keys = [a, b, c]
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("c", 3)
 
-        cache.get("b") // keys = [a, b, c, b]
-        cache.get("b") // keys = [a, b, c, b, b]
-        cache.get("b") // keys = [a, b, c, b, b, b] size at limit (maxSize * 2 = 6)
-        cache.get("a") // keys = [b, b, a] keys is over limit, only the 3 last are kept
-        cache.set("d", 4) // keys = [b, b, a, d],
+        cache.get("a")
+        cache.set("d", 4)
 
-        // @todo clarify with @staab the intended behavior
-        // "a" was recently accessed, it should not be evicted
-        expect(cache.has("a")).toBe(true) // 'a' should be present
-        expect(cache.has("b")).toBe(false) // 'b' should be evicted
+        expect(cache.has("a")).toBe(true)
+        expect(cache.has("b")).toBe(false)
+        expect(cache.has("c")).toBe(true)
+        expect(cache.has("d")).toBe(true)
+      })
+
+      it("should update access order when replacing a value", () => {
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("c", 3)
+
+        cache.set("a", 10)
+        cache.set("d", 4)
+
+        expect(cache.get("a")).toBe(10)
+        expect(cache.has("b")).toBe(false)
+      })
+
+      it("should stay within maxSize after removing an entry", () => {
+        const smallCache = new LRUCache<string, number>(2)
+
+        smallCache.set("a", 1)
+        smallCache.set("b", 2)
+        expect(smallCache.pop("a")).toBe(1)
+
+        smallCache.set("c", 3)
+        smallCache.set("d", 4)
+
+        expect(smallCache.map.size).toBe(2)
+        expect(smallCache.has("b")).toBe(false)
+        expect(smallCache.has("c")).toBe(true)
+        expect(smallCache.has("d")).toBe(true)
       })
     })
   })

--- a/packages/lib/src/LRUCache.ts
+++ b/packages/lib/src/LRUCache.ts
@@ -5,7 +5,6 @@
  */
 export class LRUCache<T, U> {
   map = new Map<T, U>()
-  keys: T[] = []
 
   constructor(readonly maxSize: number = Infinity) {}
 
@@ -14,30 +13,29 @@ export class LRUCache<T, U> {
   }
 
   get(k: T) {
-    const v = this.map.get(k)
+    if (!this.map.has(k)) return
 
-    if (v !== undefined) {
-      this.keys.push(k as T)
+    const v = this.map.get(k) as U
 
-      if (this.keys.length > this.maxSize * 2) {
-        this.keys = this.keys.splice(-this.maxSize)
-      }
-    }
+    this.map.delete(k)
+    this.map.set(k, v)
 
     return v
   }
 
   set(k: T, v: U) {
+    this.map.delete(k)
     this.map.set(k, v)
-    this.keys.push(k)
 
     if (this.map.size > this.maxSize) {
-      this.map.delete(this.keys.shift() as T)
+      const oldest = this.map.keys().next()
+
+      if (!oldest.done) this.map.delete(oldest.value)
     }
   }
 
   pop(k: T) {
-    const v = this.get(k)
+    const v = this.map.get(k)
 
     this.map.delete(k)
 


### PR DESCRIPTION
## Summary

- replace the duplicate-prone access history with `Map` insertion order
- refresh recency on cache reads and value replacements
- remove entries without leaving stale eviction records
- add regressions for read recency, replacement recency, and capacity after removal

## Problem

The history array retains duplicate and stale keys. Eviction can therefore remove a recently accessed key, or attempt to delete an absent key and leave the cache above `maxSize`.

## Verification

- `pnpm build`
- `pnpm exec vitest run` (696 passed, 1 skipped)
- pre-commit lint and documentation build